### PR TITLE
fixup: fix signatures and python2

### DIFF
--- a/.ci/Dockerfile.alpine
+++ b/.ci/Dockerfile.alpine
@@ -15,6 +15,7 @@ RUN apk update && \
             ncurses-dev \
             outils-signify \
             perl \
+            python2 \
             python3 \
             rsync \
             unzip \

--- a/.ci/Dockerfile.debian
+++ b/.ci/Dockerfile.debian
@@ -12,6 +12,7 @@ RUN apt-get update -qq &&\
         git \
         libncurses5-dev \
         libssl-dev \
+        python2.7 \
         python3 \
         signify-openbsd \
         subversion \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,31 @@
 version: 2
 jobs:
-  test-alpine:
+  test-alpine-1806:
+    docker:
+      - image: "alpine:latest"
+    environment:
+      TARGET: "ar71xx/generic"
+      PROFILE: "archer-c7-v4"
+      VERSION: "18.06.4"
+    steps:
+      - run: apk add alpine-sdk gnupg bash bzip2 coreutils curl file findutils gawk grep linux-headers ncurses-dev outils-signify perl python2 python3 rsync unzip wget xz zlib-dev
+      - checkout
+      - run: bash ./meta image
+      - run: ls ./bin/openwrt/$VERSION/$TARGET/*sysupgrade.bin
+
+  test-alpine-snapshot:
     docker:
       - image: "alpine:latest"
     environment:
       TARGET: "ath79/generic"
       PROFILE: "tplink_archer-c7-v1"
     steps:
-      - run: apk add alpine-sdk gnupg bash bzip2 coreutils curl file findutils gawk grep linux-headers ncurses-dev outils-signify perl python3 rsync unzip wget xz zlib-dev
+      - run: apk add alpine-sdk gnupg bash bzip2 coreutils curl file findutils gawk grep linux-headers ncurses-dev outils-signify perl python2 python3 rsync unzip wget xz zlib-dev
       - checkout
       - run: bash ./meta image
       - run: ls ./bin/openwrt/snapshot/$TARGET/*sysupgrade.bin
 
-  test-debian:
+  test-debian-snapshot:
     docker:
       - image: "debian:latest"
     environment:
@@ -20,7 +33,7 @@ jobs:
       PROFILE: "tplink_archer-c7-v1"
     steps:
       - run: apt-get update -qq
-      - run: apt-get install -y build-essential curl file gawk gettext git libncurses5-dev libssl-dev python3 signify-openbsd subversion swig unzip wget zlib1g-dev
+      - run: apt-get install -y build-essential curl file gawk gettext git libncurses5-dev libssl-dev python2.7 python3 signify-openbsd subversion swig unzip wget zlib1g-dev
       - checkout
       - run: bash ./meta image
       - run: ls ./bin/openwrt/snapshot/$TARGET/*sysupgrade.bin
@@ -41,12 +54,14 @@ workflows:
   version: 2
   build_test_deploy:
     jobs:
-      - test-alpine
-      - test-debian
+      - test-alpine-snapshot
+      - test-alpine-1806
+      - test-debian-snapshot
       - deploy-docker:
           requires:
-            - test-alpine
-            - test-debian
+            - test-alpine-snapshot
+            - test-alpine-1806
+            - test-debian-snapshot
           filters:
             branches:
               only:

--- a/meta
+++ b/meta
@@ -64,9 +64,9 @@ download() {
     cd "$IB_DIR"
 
     echo "download checksums and signature"
-    wget "$TARGETS_URL/sha256sums" -O sha256sums
-    wget "$TARGETS_URL/sha256sums.gpg" -O sha256sums.asc || true
-    wget "$TARGETS_URL/sha256sums.sig" -O sha256sums.sig || true
+    curl "$TARGETS_URL/sha256sums" -sS -o sha256sums
+    curl "$TARGETS_URL/sha256sums.asc" -fs -o sha256sums.asc || true
+    curl "$TARGETS_URL/sha256sums.sig" -fs -o sha256sums.sig || true
 
     if [ ! -f sha256sums.asc ] && [ ! -f sha256sums.sig ]; then
         die "Missing sha256sums signature files"


### PR DESCRIPTION
using wget created a empty file even if the signature (mostly usign)
don't exists, causing the script to fail.

Aditionally the older releases used to use .gpg signatures, however
thats a forward to .asc which must be downlaoded directly. Downloading
gpg would store a HTTP forward header instead of the signature.

Python2 is a hard requirement for older releases, adding it back.

Also added new CI test to check if older releases work.

Signed-off-by: Paul Spooren <mail@aparcar.org>