### PR TITLE
Added two more examples about LibreMesh (17.06 release and snapshot)

### DIFF
--- a/example-libremesh_17.06.sh
+++ b/example-libremesh_17.06.sh
@@ -3,7 +3,7 @@ export IB_VERSION="17.01.6"
 export DISTRO="lime"
 export TARGET="ar71xx/generic"
 export PROFILE="tl-wdr3600-v1"
-export PACKAGES="lime-system lime-proto-wan lime-hwd-openwrt-wan lime-debug smonit lime-proto-bmx6 bmx6-auto-gw-mode luci lime-docs lime-docs-minimal luci-mod-admin-full lime-map-agent lime-proto-batadv lime-proto-anygw dnsmasq-lease-share dnsmasq-distributed-hosts lime-webui lime-hwd-ground-routing -dnsmasq"
+export PACKAGES="lime-system lime-proto-wan lime-hwd-openwrt-wan lime-debug smonit lime-proto-bmx6 bmx6-auto-gw-mode luci lime-docs lime-docs-minimal luci-mod-admin-full lime-map-agent lime-proto-batadv lime-proto-anygw dnsmasq-lease-share dnsmasq-distributed-hosts lime-webui lime-hwd-ground-routing -dnsmasq -luci-app-firewall -luci-proto-ppp -luci"
 export REPOS="""src/gz reboot_core http://downloads.openwrt.org/releases/{{ ib_version }}/targets/{{ target }}/packages
 src/gz reboot_base http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/base
 src/gz reboot_luci http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/luci

--- a/example-libremesh_17.06.sh
+++ b/example-libremesh_17.06.sh
@@ -1,0 +1,17 @@
+export VERSION="17.06"
+export IB_VERSION="17.01.6"
+export DISTRO="lime"
+export TARGET="ar71xx/generic"
+export PROFILE="tl-wdr3600-v1"
+export PACKAGES="lime-system lime-proto-wan lime-hwd-openwrt-wan lime-debug smonit lime-proto-bmx6 bmx6-auto-gw-mode luci lime-docs lime-docs-minimal luci-mod-admin-full lime-map-agent lime-proto-batadv lime-proto-anygw dnsmasq-lease-share dnsmasq-distributed-hosts lime-webui lime-hwd-ground-routing"
+export REPOS="""src/gz reboot_core http://downloads.openwrt.org/releases/{{ ib_version }}/targets/{{ target }}/packages
+src/gz reboot_base http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/base
+src/gz reboot_luci http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/luci
+src/gz reboot_packages http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/packages
+src/gz reboot_routing http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/routing
+src/gz reboot_telephony http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/telephony
+src imagebuilder file:packages
+src/gz libremesh_v1706 http://downloads.libremesh.org/releases/{{ version }}/packages/{{ pkg_arch }}/libremesh/
+src/gz lm_profiles http://chef.libremesh.org/network-profiles/"""
+
+./meta image

--- a/example-libremesh_17.06.sh
+++ b/example-libremesh_17.06.sh
@@ -12,6 +12,7 @@ src/gz reboot_routing http://downloads.openwrt.org/releases/{{ ib_version }}/pac
 src/gz reboot_telephony http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/telephony
 src imagebuilder file:packages
 src/gz libremesh_v1706 http://downloads.libremesh.org/releases/{{ version }}/packages/{{ pkg_arch }}/libremesh/
+src/gz libremap http://downloads.libremesh.org/releases/{{ version }}/packages/{{ pkg_arch }}/libremap/
 src/gz lm_profiles http://chef.libremesh.org/network-profiles/"""
 
 ./meta image

--- a/example-libremesh_17.06.sh
+++ b/example-libremesh_17.06.sh
@@ -3,7 +3,7 @@ export IB_VERSION="17.01.6"
 export DISTRO="lime"
 export TARGET="ar71xx/generic"
 export PROFILE="tl-wdr3600-v1"
-export PACKAGES="lime-system lime-proto-wan lime-hwd-openwrt-wan lime-debug smonit lime-proto-bmx6 bmx6-auto-gw-mode luci lime-docs lime-docs-minimal luci-mod-admin-full lime-map-agent lime-proto-batadv lime-proto-anygw dnsmasq-lease-share dnsmasq-distributed-hosts lime-webui lime-hwd-ground-routing"
+export PACKAGES="lime-system lime-proto-wan lime-hwd-openwrt-wan lime-debug smonit lime-proto-bmx6 bmx6-auto-gw-mode luci lime-docs lime-docs-minimal luci-mod-admin-full lime-map-agent lime-proto-batadv lime-proto-anygw dnsmasq-lease-share dnsmasq-distributed-hosts lime-webui lime-hwd-ground-routing -dnsmasq"
 export REPOS="""src/gz reboot_core http://downloads.openwrt.org/releases/{{ ib_version }}/targets/{{ target }}/packages
 src/gz reboot_base http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/base
 src/gz reboot_luci http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/luci

--- a/example-libremesh_master.sh
+++ b/example-libremesh_master.sh
@@ -4,7 +4,7 @@ export DISTRO="lime"
 export TARGET="ar71xx/generic"
 export SUBTARGET="generic"
 export PROFILE="tl-wdr3600-v1"
-export PACKAGES="check-date-http first-boot-wizard hotplug-initd-services lime-app lime-debug lime-hwd-ground-routing lime-hwd-openwrt-wan lime-proto-anygw lime-proto-babeld lime-proto-batadv lime-proto-wan lime-system shared-state shared-state-babeld_hosts shared-state-dnsmasq_hosts shared-state-bat_hosts shared-state-persist shared-state-dnsmasq_leases shared-state-pirania shared-state-nodes_and_links lime-docs lime-docs-minimal"
+export PACKAGES="check-date-http first-boot-wizard hotplug-initd-services lime-app lime-debug lime-hwd-ground-routing lime-hwd-openwrt-wan lime-proto-anygw lime-proto-babeld lime-proto-batadv lime-proto-wan lime-system shared-state shared-state-babeld_hosts shared-state-dnsmasq_hosts shared-state-bat_hosts shared-state-dnsmasq_leases shared-state-nodes_and_links lime-docs lime-docs-minimal libremap-agent -dnsmasq -firewall"
 export REPOS="""src/gz v18064_core http://downloads.openwrt.org/releases/{{ ib_version }}/targets/{{ target }}/packages
 src/gz v18064_base http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/base
 src/gz v18064_luci http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/luci
@@ -13,6 +13,7 @@ src/gz v18064_routing http://downloads.openwrt.org/releases/{{ ib_version }}/pac
 src/gz v18064_telephony http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/telephony
 src imagebuilder file:packages
 src/gz libremesh_master http://snapshots.libremesh.org/packages/
+src/gz libremap http://downloads.libremesh.org/releases/18.06.1/packages/{{ pkg_arch }}/libremap/
 src/gz lm_profiles http://chef.libremesh.org/network-profiles/"""
 
 ./meta image

--- a/example-libremesh_master.sh
+++ b/example-libremesh_master.sh
@@ -1,0 +1,18 @@
+export VERSION="master"
+export IB_VERSION="18.06.4"
+export DISTRO="lime"
+export TARGET="ar71xx/generic"
+export SUBTARGET="generic"
+export PROFILE="tl-wdr3600-v1"
+export PACKAGES="check-date-http first-boot-wizard hotplug-initd-services lime-app lime-debug lime-hwd-ground-routing lime-hwd-openwrt-wan lime-proto-anygw lime-proto-babeld lime-proto-batadv lime-proto-wan lime-system shared-state shared-state-babeld_hosts shared-state-dnsmasq_hosts shared-state-bat_hosts shared-state-persist shared-state-dnsmasq_leases shared-state-pirania shared-state-nodes_and_links lime-docs lime-docs-minimal"
+export REPOS="""src/gz v18064_core http://downloads.openwrt.org/releases/{{ ib_version }}/targets/{{ target }}/packages
+src/gz v18064_base http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/base
+src/gz v18064_luci http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/luci
+src/gz v18064_packages http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/packages
+src/gz v18064_routing http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/routing
+src/gz v18064_telephony http://downloads.openwrt.org/releases/{{ ib_version }}/packages/{{ pkg_arch }}/telephony
+src imagebuilder file:packages
+src/gz libremesh_master http://snapshots.libremesh.org/packages/
+src/gz lm_profiles http://chef.libremesh.org/network-profiles/"""
+
+./meta image


### PR DESCRIPTION
Based on the example-libremesh.sh file I created two additional example files for compiling the LibreMesh 17.06 release and the latest code.

There are a couple of problems:

in LibreMesh 17.06 by default we unselected the `dnsmasq` package for being able to select `dnsmasq-dhcpv6` and I think that in the release also the `firewall` was deselected. Can this be done with this metabuilder?

for compiling the snapshot images of LibreMesh we need the compiled LibreMesh packages which currently are missing from http://snapshots.libremesh.org/packages/ and I have no idea of who is in charge of this.