### PR TITLE
rename version to snapshot not snapshots

### DIFF
--- a/example-snapshot.sh
+++ b/example-snapshot.sh
@@ -1,5 +1,5 @@
 export DISTRO="openwrt"
-export VERSION="snapshots"
+export VERSION="snapshot"
 export TARGET="ath79/generic"
 export PROFILE="etactica_eg200"
 export PACKAGES="tmux htop"

--- a/meta
+++ b/meta
@@ -10,10 +10,10 @@ ROOT_DIR="$PWD" # where the script is
 IB="imagebuilder" # search sha256sums for this string to find imagebuilder
 BUILD_KEY="${BUILD_KEY:-$ROOT_DIR/key-build}"
 DISTRO="${DISTRO:-openwrt}" # the folder where to store created files
-VERSION="${VERSION:-snapshots}" # default version
+VERSION="${VERSION:-snapshot}" # default version
 IB_VERSION="${IB_VERSION:-$VERSION}" # ImabeBuilder version if different to distro version
 FILE_HOST="${FILE_HOST:-downloads.openwrt.org}" # download imagebuilders
-[ "$IB_VERSION" != "snapshots" ] && {
+[ "$IB_VERSION" != "snapshot" ] && {
     VERSION_PATH="releases/$IB_VERSION"
 } || {
     VERSION_PATH="snapshots"


### PR DESCRIPTION
the folders are called snapshots, but the devices identifies itself as
snapshot.

Signed-off-by: Paul Spooren <mail@aparcar.org>