### PR TITLE
Add 18.06 release key v2 and public usign key

### DIFF
--- a/meta
+++ b/meta
@@ -61,6 +61,10 @@ meta_setup() {
     curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=gpg/17E1CE16.asc' | gpg --import \
             && echo '6768C55E79B032D77A28DA5F0F20257417E1CE16:6:' | gpg --import-ownertrust
 
+    # OpenWrt Release Builder (18.06 Signing Key v2)
+    curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=gpg/15807931.asc' | gpg --import \
+            && echo 'AD0507363D2BCE9C9E36CEC4FBCB78F015807931:6:' | gpg --import-ownertrust
+
     # LEDE Build System (LEDE usign key for unattended build jobs)
     curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=usign/b5043e70f9a75cde' --create-dirs \
             -o ./usign/b5043e70f9a75cde
@@ -68,6 +72,10 @@ meta_setup() {
     # Public usign key for unattended snapshot builds
     curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=usign/b5043e70f9a75cde' --create-dirs \
             -o ./usign/b5043e70f9a75cde
+
+    # Public usign key for 18.06 release builds
+    curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=usign/1035ac73cc4e59e3' --create-dirs \
+            -o ./usign/1035ac73cc4e59e3
 
     # Public usign key for 19.07 release builds
     curl 'https://git.openwrt.org/?p=keyring.git;a=blob_plain;f=usign/f94b9dd6febac963' --create-dirs \


### PR DESCRIPTION
This adds support for the 18.06 signing key v2 and public usign key introduced in https://git.openwrt.org/?p=keyring.git;a=commit;h=228f8dad591f61166578dbbfdc5aa7ba93e00b62 and https://git.openwrt.org/?p=keyring.git;a=commit;h=999c3f171881555e20ae801f7fe02f3bd6091287

These are required for 18.06.5.